### PR TITLE
Refactor: Migrate to View Binding and add string resources

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,9 @@ android {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
         }
     }
+    buildFeatures{
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,7 +29,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Calculadora Propinas"
+                android:text="@string/tip_calculator_title"
                 android:textSize="24sp"
                 android:textStyle="bold"
                 android:layout_gravity="center_horizontal"
@@ -40,30 +40,32 @@
                 android:id="@+id/txtAnteriorPorcentaje"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Tu anterior porcentaje fue: "
+                android:text="@string/previous_tip_percentage"
                 android:visibility="gone"/>
 
             <!-- Monto toal Input -->
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Ingrese total"
+                android:text="@string/enter_total_label"
                 android:textSize="16sp"
                 android:layout_marginBottom="4dp"/>
             <EditText
                 android:id="@+id/inputMontoTotal"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="Ingrese monto"
+                android:hint="@string/enter_total_hint"
                 android:inputType="numberDecimal"
                 android:padding="12dp"
-                android:layout_marginBottom="16dp"/>
+                android:layout_marginBottom="16dp"
+                android:maxLength="9"
+                tools:ignore="Autofill" />
 
             <!-- Propina porcentaje Selection -->
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Procentaje de propina"
+                android:text="@string/tip_percentage_label"
                 android:textSize="16sp"
                 android:layout_marginBottom="4dp"/>
             <RadioGroup
@@ -78,25 +80,25 @@
                     android:id="@+id/rBtn_10"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="10%" />
+                    android:text="@string/tip_10_percent" />
 
                 <RadioButton
                     android:id="@+id/rBtn_15"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="15%" />
+                    android:text="@string/tip_15_percent" />
 
                 <RadioButton
                     android:id="@+id/rBtn_20"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="20%" />
+                    android:text="@string/tip_20_percent" />
 
                 <RadioButton
                     android:id="@+id/rBtn_personalizado"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="¿Otro?" />
+                    android:text="@string/tip_custom_option" />
             </RadioGroup>
 
             <!-- Propina personalizada Input Field -->
@@ -104,14 +106,17 @@
                 android:id="@+id/edTxtCantidadPorcentajePersonalizada"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="ej: 18"
+                android:hint="@string/custom_tip_hint"
                 android:inputType="number"
                 android:padding="12dp"
                 android:visibility="gone"
-                android:layout_marginBottom="16dp"/>
+                android:layout_marginBottom="16dp"
+                android:maxLength="2"
+                tools:ignore="Autofill" />
 
             <!-- Calcular limpiar Buttons -->
             <LinearLayout
+                style="?android:attr/buttonBarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
@@ -119,20 +124,22 @@
 
                 <Button
                     android:id="@+id/btnCalcular"
+                    style="?android:attr/buttonBarButtonStyle"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Calcular"
+                    android:text="@string/calculate_button"
                     android:backgroundTint="#4CAF50"
                     android:textColor="@android:color/white"
-                    android:layout_marginEnd="8dp"/>
+                    android:layout_marginEnd="8dp" />
 
                 <Button
                     android:id="@+id/btnLimpiar"
+                    style="?android:attr/buttonBarButtonStyle"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:text="Limpiar"
+                    android:text="@string/clear_button"
                     android:backgroundTint="#E0E0E0"
                     android:textColor="@android:color/black"
                     android:layout_marginStart="8dp"/>
@@ -140,15 +147,17 @@
 
             <!-- propina Result -->
             <LinearLayout
+                android:id="@+id/propina_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:layout_marginBottom="8dp">
+                android:layout_marginBottom="8dp"
+                android:visibility="gone">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Propina"
+                    android:text="@string/tip_label"
                     android:textSize="16sp"/>
 
                 <View
@@ -160,7 +169,7 @@
                     android:id="@+id/txtPropina"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="$0.00"
+                    android:text="@string/placeholder_amount"
                     android:textSize="16sp"
                     android:textStyle="bold"
                     android:gravity="end"
@@ -169,14 +178,16 @@
 
             <!-- Total  Result -->
             <LinearLayout
+                android:id="@+id/total_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:visibility="gone">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Total"
+                    android:text="@string/total_label"
                     android:textSize="18sp"
                     android:textStyle="bold"/>
 
@@ -189,7 +200,7 @@
                     android:id="@+id/txtTotal"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="$0.00"
+                    android:text="@string/placeholder_amount"
                     android:textSize="18sp"
                     android:textStyle="bold"
                     android:gravity="end"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,18 @@
 <resources>
     <string name="app_name">DefLatam_CalculadoraPropinas</string>
+    <string name="tip_calculator_title">Calculadora Propinas</string>
+    <string name="previous_tip_percentage">Tu anterior porcentaje fue: </string>
+    <string name="enter_total_label">Ingrese total</string>
+    <string name="enter_total_hint">Ingrese monto</string>
+    <string name="tip_percentage_label">Procentaje de propina</string>
+    <string name="tip_10_percent">10%</string>
+    <string name="tip_15_percent">15%</string>
+    <string name="tip_20_percent">20%</string>
+    <string name="tip_custom_option">¿Otro?</string>
+    <string name="custom_tip_hint">ej: 18</string>
+    <string name="calculate_button">Calcular</string>
+    <string name="clear_button">Limpiar</string>
+    <string name="tip_label">Propina:</string>
+    <string name="total_label">Total:</string>
+    <string name="placeholder_amount">$0.00</string>
 </resources>


### PR DESCRIPTION
This commit migrates `MainActivity` to use View Binding instead of `findViewById`. It also externalizes UI strings into `strings.xml` and makes corresponding updates in `activity_main.xml` and `MainActivity.kt`.

Key changes:
- Enabled View Binding in `app/build.gradle.kts`.
- Replaced `findViewById` calls with View Binding in `MainActivity.kt`.
- Added new string resources to `app/src/main/res/values/strings.xml` for labels, hints, and button text.
- Updated `app/src/main/res/layout/activity_main.xml` to use the new string resources.
- Introduced `maxLength` attributes for `inputMontoTotal` and `edTxtCantidadPorcentajePersonalizada` EditTexts.
- Set `visibility` to `gone` by default for `propina_layout` and `total_layout` in `activity_main.xml`.
- Modified `calculosTotalesYpropina` in `MainActivity.kt` to show `propinaLayout` and `totalLayout` with fade animations when results are calculated.
- Updated `limpiarCampos` to hide `propinaLayout` and `totalLayout` with fade animations.
- Added a `try-catch` block in `calculosTotalesYpropina` for error handling during calculations.
- Renamed and adjusted visibility of some methods in `MainActivity.kt` to private.